### PR TITLE
Fix: check if order does not exist on stripe webhook boilerplate

### DIFF
--- a/COPY-PASTE-LIST.md
+++ b/COPY-PASTE-LIST.md
@@ -191,7 +191,7 @@ const { docs: orders } = await payload.find({
 
 const [order] = orders
 
-if (!user) return res.status(404).json({ error: 'No such order exists.' })
+if (!order) return res.status(404).json({ error: 'No such order exists.' })
 
 await payload.update({
     collection: 'orders',


### PR DESCRIPTION
There is a small mistake in the `COPY-PASTE-LIST.md` where it is checked if the user exists twice (stripe webhook boilerplate).